### PR TITLE
Bump Dash SDK version to `1.0.0-beta.18`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,7 +66,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mapbox.dash:android:1.0.0-beta.16")
+    implementation("com.mapbox.dash:android:1.0.0-beta.18")
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.1")


### PR DESCRIPTION
- Bumps Dash SDK version to `1.0.0-beta.18`

cc @zugaldia @ilyasubbotin @alexzatsepin @dmhorton-mapbox