### PR TITLE
Add custom voice player example

### DIFF
--- a/app/src/main/java/com/mapbox/dash/example/LocalVoicePlayerMiddleware.kt
+++ b/app/src/main/java/com/mapbox/dash/example/LocalVoicePlayerMiddleware.kt
@@ -1,0 +1,300 @@
+package com.mapbox.dash.example
+
+import android.content.Context
+import android.os.Bundle
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import com.mapbox.dash.sdk.CoroutineMiddleware
+import com.mapbox.dash.sdk.audiofocus.AudioFocusOwner
+import com.mapbox.navigation.mapgpt.shared.common.SharedLog
+import com.mapbox.navigation.mapgpt.shared.language.Language
+import com.mapbox.navigation.mapgpt.shared.textplayer.Announcement
+import com.mapbox.navigation.mapgpt.shared.textplayer.PlayerCallback
+import com.mapbox.navigation.mapgpt.shared.textplayer.Voice
+import com.mapbox.navigation.mapgpt.shared.textplayer.VoicePlayer
+import com.mapbox.navigation.mapgpt.shared.textplayer.VoiceProgress
+import com.mapbox.navigation.mapgpt.shared.textplayer.middleware.VoicePlayerMiddleware
+import com.mapbox.navigation.mapgpt.shared.textplayer.middleware.VoicePlayerMiddlewareContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import java.util.Locale
+
+class LocalVoicePlayerMiddleware :
+    VoicePlayerMiddleware,
+    CoroutineMiddleware<VoicePlayerMiddlewareContext>() {
+
+    private val _availableLanguages = MutableStateFlow(emptySet<Language>())
+    override val availableLanguages: StateFlow<Set<Language>> = _availableLanguages.asStateFlow()
+
+    private val _availableVoices = MutableStateFlow(emptySet<Voice>())
+    override val availableVoices: StateFlow<Set<Voice>> = _availableVoices.asStateFlow()
+
+    private var voicePlayer: LocalVoicePlayer? = null
+
+    override fun onAttached(middlewareContext: VoicePlayerMiddlewareContext) {
+        super.onAttached(middlewareContext)
+        SharedLog.i(TAG) { "onAttached" }
+        voicePlayer = LocalVoicePlayer(
+            middlewareContext.platformContext.applicationContext,
+        ).also { voicePlayer ->
+            attachVoiceCapabilities(voicePlayer)
+        }
+    }
+
+    override fun onDetached(middlewareContext: VoicePlayerMiddlewareContext) {
+        super.onDetached(middlewareContext)
+        SharedLog.i(TAG) { "onDetached" }
+        _availableLanguages.value = emptySet()
+        _availableVoices.value = emptySet()
+        release()
+    }
+
+    override fun prefetch(announcement: Announcement) {
+        // No-op: nothing to prefetch
+    }
+
+    override fun play(
+        announcement: Announcement,
+        progress: VoiceProgress?,
+        callback: PlayerCallback,
+    ) {
+        SharedLog.d(TAG) { "play $announcement" }
+        val middlewareContext = middlewareContext ?: run {
+            callback.onError(announcement.utteranceId, "Middleware context is not available")
+            return
+        }
+
+        middlewareContext.audioFocusManager.request(AudioFocusOwner.TextToSpeech) { isGranted ->
+            if (isGranted) {
+                voicePlayer?.play(announcement, progress, callback)
+            } else {
+                callback.onError(announcement.utteranceId, "Audio focus is not granted")
+            }
+        }
+    }
+
+    override fun stop() {
+        voicePlayer?.stop()
+    }
+
+    override fun release() {
+        voicePlayer?.release()
+    }
+
+    override fun volume(level: Float) {
+        if (level in 0.0f..1.0f) {
+            voicePlayer?.volume(level)
+        }
+    }
+
+    private fun attachVoiceCapabilities(voicePlayer: VoicePlayer) {
+        voicePlayer.availableLanguages.onEach { availableLanguages ->
+            _availableLanguages.value = availableLanguages
+        }.launchIn(ioScope)
+        voicePlayer.availableVoices.onEach { availableVoices ->
+            _availableVoices.value = availableVoices
+        }.launchIn(ioScope)
+    }
+
+    private companion object {
+        private const val TAG = "LocalVoicePlayerMiddleware"
+    }
+}
+
+class AndroidTextToSpeechVoice(
+    val voice: android.speech.tts.Voice,
+) : Voice {
+    override fun toString(): String {
+        return "AndroidTextToSpeechVoice(voice=$voice)"
+    }
+}
+
+internal class LocalVoicePlayer(
+    androidContext: Context,
+    private val initialLanguage: Language = Language(Locale.ENGLISH),
+    private val initialTtsEngine: String = "com.google.android.tts",
+) : VoicePlayer {
+
+    private var textToSpeechInitStatus: Int? = null
+    private var volume = 1.0f
+
+    private val _availableLanguages = MutableStateFlow(emptySet<Language>())
+    override val availableLanguages: StateFlow<Set<Language>> = _availableLanguages.asStateFlow()
+
+    private val _availableVoices = MutableStateFlow(emptySet<Voice>())
+    override val availableVoices: StateFlow<Set<Voice>> = _availableVoices.asStateFlow()
+
+    private var language: Language = initialLanguage
+
+    private val textToSpeech = TextToSpeech(
+        androidContext,
+        { status ->
+            textToSpeechInitStatus = status
+            if (status == TextToSpeech.SUCCESS) {
+                initializeWithLanguage()
+            }
+        },
+        initialTtsEngine,
+    )
+
+    private fun initializeWithLanguage() {
+        SharedLog.d(TAG) { "Available tts engines: ${textToSpeech.engines.joinToString()}" }
+        val enginePackages = textToSpeech.engines.map { it.name }.toSet()
+        if (!enginePackages.contains(initialTtsEngine)) {
+            SharedLog.w(TAG) {
+                "The initialTtsEngine was not found: $initialTtsEngine. " +
+                        "Using ${textToSpeech.defaultEngine}"
+            }
+        } else {
+            SharedLog.i(TAG) { "Using tts engine: $initialTtsEngine" }
+        }
+        try {
+            // there is a chance to get NPE from ITextToSpeechService getting the voices that
+            // means we're not able to use TTS
+            // https://issuetracker.google.com/issues/37012397?pli=1
+            textToSpeech.voices
+        } catch (e: NullPointerException) {
+            SharedLog.w(TAG) { "Calling textToSpeech.voices causes NullPointerException" }
+            textToSpeechInitStatus = TextToSpeech.ERROR
+            return
+        }
+
+        val availableLocales = textToSpeech.availableLanguages
+        SharedLog.i(TAG) { "Available languages: ${availableLocales.joinToString { it.isO3Language }}" }
+        _availableLanguages.value = availableLocales.map { Language(it) }.toSet()
+        SharedLog.d(TAG) { "Searching for TTS language: ${initialLanguage.locale.isO3Language}" }
+        val targetLocale = availableLocales.firstOrNull {
+            it.isO3Language == initialLanguage.locale.isO3Language
+        }
+        SharedLog.i(TAG) { "Found TTS language: ${targetLocale?.isO3Language}" }
+        val locale: Locale = targetLocale?.let {
+            targetLocale.also { language = Language(it) }
+        } ?: run {
+            SharedLog.w(TAG) { "${language.locale} is not supported, using $defaultLocale" }
+            defaultLocale
+        }
+
+        updateAvailableVoices(locale)
+
+        SharedLog.d(TAG) { "Set language to $locale" }
+        val setLanguageResult = textToSpeech.setLanguage(locale)
+        SharedLog.d(TAG) { "setLanguageResult: $setLanguageResult" }
+        SharedLog.d(TAG) { "TextToSpeech voice: ${textToSpeech.voice}" }
+    }
+
+    private fun updateAvailableVoices(locale: Locale) {
+        val availableVoices = textToSpeech.voices.mapNotNull { voice ->
+            val voiceLanguage = Language(voice.locale)
+            if (voiceLanguage == language) {
+                AndroidTextToSpeechVoice(voice)
+            } else {
+                null
+            }
+        }.toSet()
+        if (availableVoices.isNotEmpty()) {
+            _availableVoices.value = availableVoices
+        } else {
+            val defaultVoice = textToSpeech.voice
+            SharedLog.w(TAG) { "No voice for $locale, fallback to $defaultVoice" }
+            _availableVoices.value = defaultVoice
+                ?.let { setOf(AndroidTextToSpeechVoice(it)) }
+                ?: emptySet()
+        }
+        SharedLog.d(TAG) { "Available voices: ${_availableVoices.value}" }
+    }
+
+    override fun prefetch(announcement: Announcement) = Unit
+
+    override fun play(
+        announcement: Announcement,
+        progress: VoiceProgress?,
+        callback: PlayerCallback,
+    ) {
+        val startPosition = (progress as? VoiceProgress.Index)?.position ?: 0
+        textToSpeech.setOnUtteranceProgressListener(
+            UtteranceProgressListenerWrapper(
+                announcement.text,
+                startPosition,
+                callback,
+            ),
+        )
+        val bundle = Bundle().apply {
+            putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, volume)
+        }
+        if (textToSpeechInitStatus == TextToSpeech.SUCCESS) {
+            textToSpeech.speak(
+                announcement.text,
+                TextToSpeech.QUEUE_FLUSH,
+                bundle,
+                announcement.utteranceId,
+            )
+        } else {
+            callback.onError(announcement.utteranceId, "TTS is not initialized")
+        }
+    }
+
+    override fun stop() {
+        textToSpeech.stop()
+    }
+
+    override fun release() = Unit
+
+    override fun volume(level: Float) {
+        volume = level
+    }
+
+    inner class UtteranceProgressListenerWrapper(
+        private val text: String?,
+        private val initialStartPosition: Int,
+        private val clientCallback: PlayerCallback,
+    ) : UtteranceProgressListener() {
+
+        private var currentPosition: Int = 0
+        override fun onStart(utteranceId: String) {
+            SharedLog.d(TAG) { "onStart $utteranceId" }
+            clientCallback.onStartPlaying(text = text, utteranceId = utteranceId)
+        }
+
+        override fun onRangeStart(utteranceId: String, start: Int, end: Int, frame: Int) {
+            SharedLog.d(TAG) { "onRangeStart $utteranceId, start: $start, end $end, frame $frame" }
+            currentPosition = initialStartPosition + start
+        }
+
+        override fun onDone(utteranceId: String) {
+            SharedLog.d(TAG) { "onDone $utteranceId" }
+            clientCallback.onComplete(text = text, utteranceId = utteranceId)
+            currentPosition = 0
+        }
+
+        @Deprecated("Deprecated in Java")
+        override fun onError(utteranceId: String) {
+            // Deprecated, may be called due to https://issuetracker.google.com/issues/138321382
+            SharedLog.d(TAG) { "onError $utteranceId" }
+            clientCallback.onError(utteranceId, null)
+            currentPosition = 0
+        }
+
+        override fun onError(utteranceId: String, errorCode: Int) {
+            SharedLog.d(TAG) { "onError $utteranceId, errorCode: $errorCode" }
+            clientCallback.onError(utteranceId, errorCode.toString())
+            currentPosition = 0
+        }
+
+        override fun onStop(utteranceId: String, interrupted: Boolean) {
+            SharedLog.d(TAG) { "onStop $utteranceId, interrupted: $interrupted" }
+            clientCallback.onStop(
+                utteranceId,
+                VoiceProgress.Index(position = currentPosition),
+            )
+            currentPosition = 0
+        }
+    }
+
+    private companion object {
+        private const val TAG = "LocalVoicePlayer"
+        private val defaultLocale = Locale.ENGLISH
+    }
+}

--- a/app/src/main/java/com/mapbox/dash/example/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/dash/example/MainActivity.kt
@@ -169,6 +169,7 @@ class MainActivity : DrawerActivity() {
     private val showTripProgress = MutableStateFlow(value = true)
     private val setCustomDestination = MutableStateFlow(value = true)
     private val simpleCardHeader = MutableStateFlow(value = false)
+    private val setCustomVoicePlayer = MutableStateFlow(value = false)
 
     private fun initCustomizationMenu() {
         headlessModeCustomization()
@@ -506,6 +507,17 @@ class MainActivity : DrawerActivity() {
                 } else {
                     fragment.setPlacesPreview { DefaultPlacesPreview(state = it) }
                 }
+            }
+        }
+
+        bindSwitch(
+            switch = menuBinding.toggleCustomVoicePlayer,
+            state = setCustomVoicePlayer,
+        ) { enabled ->
+            if (enabled) {
+                Dash.controller.setVoicePlayerMiddleware(LocalVoicePlayerMiddleware())
+            } else {
+                Dash.controller.setDefaultVoicePlayerMiddleware()
             }
         }
 

--- a/app/src/main/res/layout/layout_customization_menu.xml
+++ b/app/src/main/res/layout/layout_customization_menu.xml
@@ -468,6 +468,14 @@
             android:textAllCaps="true"
             />
 
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleCustomVoicePlayer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Enable custom voice player"
+            android:textAllCaps="true"
+            />
+
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## The configuration for offline TTS

Aside from injecting your own text-to-speech (TTS) engine, if your intention is to use the local (offline) TTS engine, there is a configuration for that:
```kotlin
Dash.init(
    context = applicationContext,
    accessToken = getString(R.string.mapbox_access_token),
) {
    voices {
        preferLocalTts = true
    }
}
```

If you want to change this setting at runtime, for example, to give users the ability to change the setting, you can do so:
```kotlin
Dash.applyUpdate {
    voices {
        preferLocalTts = true
    }
}
```

## Description of this example

This implementation of `VoicePlayerMiddleware` is a `LocalVoicePlayerMiddleware`, which utilizes the Android SDK's [TextToSpeech](https://developer.android.com/reference/android/speech/tts/TextToSpeech) instance to generate audio from text.

The Mapbox `VoicePlayer` interface supports both remote and local solutions for text-to-speech (TTS). The local TTS is beneficial for offline mode or for users who prefer to save on network data. By default, the Mapbox SDK switches between local and remote voice players based on network availability. Remote voice players use advanced models for realistic voice synthesis.

### Enable example through the left panel

<img src="https://github.com/user-attachments/assets/8274a54e-f81a-4c06-8b97-0d67bd7eb514" width="300"/>



### Logs showing callbacks during navigation

```
17:11:52.886  I  [LocalVoicePlayerMiddleware]: onAttached
17:11:52.962  D  [LocalVoicePlayer]: Available tts engines: EngineInfo{name=com.google.android.tts}
17:11:52.964  I  [LocalVoicePlayer]: Using tts engine: com.google.android.tts
17:11:54.059  I  [LocalVoicePlayer]: Available languages: mai, hrv, kor, mar, asm, rus, zho, hun, swa, snd, kas, tha, doi, urd, nob, dan, tur, est, por, vie, eng, sat, sqi, swe, ara, srp, sun, ben, bos, mni, guj, kan, ell, hin, heb, fin, ben, khm, fra, ukr, pan, eng, fra, nld, lav, por, mal, deu, sin, ces, isl, pol, cat, slk, ita, fil, lit, nep, msa, eng, nld, zho, spa, tam, jpn, bul, cym, ori, brx, san, yue, eng, spa, kok, jav, slv, ind, tel, ron, eng
17:11:54.062  D  [LocalVoicePlayer]: Searching for TTS language: eng
17:11:54.063  I  [LocalVoicePlayer]: Found TTS language: eng
17:11:54.646  D  [LocalVoicePlayer]: Available voices: [AndroidTextToSpeechVoice(voice=Voice[Name: en-AU-language, locale: en_AU, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, legacySetLanguageVoice, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-us-x-tpf-local, locale: en_US, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-in-x-end-network, locale: en_IN, quality: 400, latency: 200, requiresNetwork: true, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-au-x-aua-network, locale: en_AU, quality: 400, latency: 200, requiresNetwork: true, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-GB-language, locale: en_GB, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, legacySetLanguageVoice, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-gb-x-gba-network, locale: en_GB, quality: 400, latency: 200, requiresNetwork: true, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-us-x-sfg-network, locale: en_US, quality: 400, latency: 200, requiresNetwork: true, features: [networkTimeoutMs, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-au-x-aud-local, locale: en_AU, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-au-x-aua-local, locale: en_AU, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-gb-x-gbc-network, locale: en_GB, quality: 400, latency: 200, requiresNetwork: true, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-us-x-sfg-local, locale: en_US, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-in-x-ene-local, locale: en_IN, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-us-x-iob-local, locale: en_US, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-au-x-auc-network, locale: en_AU, quality: 400, latency: 200, requiresNetwork: true, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-gb-x-gbc-local, locale: en_GB, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-us-x-tpd-network, locale: en_US, quality: 400, latency: 200, requiresNetwork: true, features: [networkTimeoutMs, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-us-x-tpc-network, locale: en_US, quality: 400, latency: 200, requiresNetwork: true, features: [networkTimeoutMs, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-au-x-aub-local, locale: en_AU, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-in-x-end-local, locale: en_IN, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-gb-x-gbb-local, locale: en_GB, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, notInstalled, networkRetriesCount]]), AndroidTextToSpeechVoice(voice=Voice[Name: en-us-x-iob-network, locale: en_US, quality: 400, latency: 2
17:11:54.651  D  [LocalVoicePlayer]: Set language to en_US
17:11:55.344  D  [LocalVoicePlayer]: setLanguageResult: 1
17:11:56.001  D  [LocalVoicePlayer]: TextToSpeech voice: Voice[Name: en-US-language, locale: en_US, quality: 400, latency: 200, requiresNetwork: false, features: [networkTimeoutMs, legacySetLanguageVoice, networkRetriesCount]]
17:12:38.095  D  [LocalVoicePlayerMiddleware]: play Priority(utteranceId='c99908c4-93fa-4f00-9878-53af81033a3a', mediaCacheId=-26699363, text='Drive west on Church Street Northwest. Then, in 400 feet, Turn left onto 16th Street Northwest.', voice=DashVoice(personaVoiceId=EXAVITQu4vr4xnSDxMaL, personaName=Voice 1)
17:12:38.654  D  [LocalVoicePlayer]: onStart c99908c4-93fa-4f00-9878-53af81033a3a
17:12:38.813  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 0, end 5, frame 360
17:12:39.250  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 6, end 10, frame 9000
17:12:39.531  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 11, end 13, frame 15719
17:12:39.711  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 14, end 20, frame 19919
17:12:40.003  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 21, end 27, frame 27000
17:12:40.285  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 28, end 37, frame 33719
17:12:41.288  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 39, end 43, frame 58006
17:12:41.848  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 45, end 47, frame 71325
17:12:41.983  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 48, end 56, frame 74805
17:12:43.152  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 58, end 62, frame 102285
17:12:43.387  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 63, end 67, frame 108045
17:12:43.675  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 68, end 72, frame 114885
17:12:43.864  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 73, end 77, frame 119805
17:12:44.416  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 78, end 84, frame 132645
17:12:44.713  D  [LocalVoicePlayer]: onRangeStart c99908c4-93fa-4f00-9878-53af81033a3a, start: 85, end 94, frame 139845
17:12:46.046  D  [LocalVoicePlayer]: onDone c99908c4-93fa-4f00-9878-53af81033a3a
```
