### PR TITLE
Add example of places list customization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.5.3")
     implementation("androidx.navigation:navigation-ui-ktx:2.5.3")
     implementation("androidx.compose.material:material:1.4.3")
+    implementation("androidx.compose.ui:ui-tooling:1.4.3")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/mapbox/dash/example/SamplePlacesViewComposer.kt
+++ b/app/src/main/java/com/mapbox/dash/example/SamplePlacesViewComposer.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.dash.example
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -9,7 +10,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -27,6 +27,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
@@ -45,6 +46,16 @@ import com.mapbox.nav.gm.map.presentation.ui.BackCloseButtonHandler
 import com.mapbox.nav.gm.map.presentation.ui.PlacesListUiState
 
 object SamplePlacesViewComposer {
+
+    @Composable
+    fun isTablet(): Boolean {
+        val configuration = LocalConfiguration.current
+        return if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            configuration.screenWidthDp > 840
+        } else {
+            configuration.screenWidthDp > 600
+        }
+    }
 
     @Composable
     fun ShimmerItem(modifier: Modifier, shape: Shape = RoundedCornerShape(8.dp)) {
@@ -180,7 +191,7 @@ object SamplePlacesViewComposer {
     ) {
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxWidth(fraction = if (isTablet()) 0.5f else 1f)
                 .background(AppTheme.colors.backgroundColors.primary, shape = AppTheme.shapes.poiCardBackground)
         ) {
             PlacesHeader(

--- a/app/src/main/java/com/mapbox/dash/example/SamplePlacesViewComposer.kt
+++ b/app/src/main/java/com/mapbox/dash/example/SamplePlacesViewComposer.kt
@@ -2,7 +2,6 @@
 
 package com.mapbox.dash.example
 
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -91,17 +90,40 @@ object SamplePlacesViewComposer {
     }
 
     @Composable
-    internal fun SearchResultPlaceholder(modifier: Modifier = Modifier) {
-        Column(modifier = modifier) {
-            ShimmerItem(
+    internal fun SearchResultPlaceholder() {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+                .background(
+                    AppTheme.colors.backgroundColors.tertiary,
+                    shape = AppTheme.shapes.searchPanelBackground,
+                ),
+        ) {
+            Column(
                 modifier = Modifier
-                    .height(24.dp)
-                    .width(370.dp),
-            )
-            val secondRowModifier = Modifier
-                .padding(top = 4.dp)
-                .height(34.dp)
-            ShimmerItem(modifier = secondRowModifier.defaultMinSize(440.dp))
+                    .padding(16.dp)
+                    .fillMaxWidth()
+            ) {
+                ShimmerItem(
+                    modifier = Modifier
+                        .height(24.dp)
+                        .width(370.dp),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                ShimmerItem(
+                    modifier = Modifier
+                        .height(34.dp)
+                        .width(370.dp),
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                ShimmerItem(
+                    modifier = Modifier
+                        .height(34.dp)
+                        .width(370.dp),
+                )
+            }
         }
     }
 
@@ -156,9 +178,11 @@ object SamplePlacesViewComposer {
         lazyListState: LazyListState,
         placesListUiState: PlacesListUiState,
     ) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .background(AppTheme.colors.backgroundColors.primary, shape = AppTheme.shapes.poiCardBackground)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(AppTheme.colors.backgroundColors.primary, shape = AppTheme.shapes.poiCardBackground)
+        ) {
             PlacesHeader(
                 title = placesListUiState.title.content.orEmpty(),
                 backButtonHandler = placesListUiState.backHandler,

--- a/app/src/main/java/com/mapbox/dash/example/SamplePlacesViewComposer.kt
+++ b/app/src/main/java/com/mapbox/dash/example/SamplePlacesViewComposer.kt
@@ -2,6 +2,7 @@
 
 package com.mapbox.dash.example
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -30,13 +31,18 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mapbox.dash.compose.component.Body1
 import com.mapbox.dash.compose.component.Title4
 import com.mapbox.dash.compose.component.Title5
+import com.mapbox.dash.example.SamplePlacesViewComposer.PlacesHeader
 import com.mapbox.dash.sdk.config.api.UiStates
 import com.mapbox.dash.theming.compose.AppTheme
+import com.mapbox.dash.theming.compose.LightDashTheme
 import com.mapbox.dash.view.compose.R
+import com.mapbox.nav.gm.map.presentation.ui.BackCloseButtonHandler
 import com.mapbox.nav.gm.map.presentation.ui.PlacesListUiState
 
 object SamplePlacesViewComposer {
@@ -100,16 +106,17 @@ object SamplePlacesViewComposer {
     }
 
     @Composable
-    operator fun invoke(
-        lazyListState: LazyListState,
-        placesListUiState: PlacesListUiState,
+    internal fun PlacesHeader(
+        title: String,
+        backButtonHandler: BackCloseButtonHandler?,
+        closeButtonHandler: BackCloseButtonHandler?,
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(32.dp),
         ) {
-            placesListUiState.backHandler?.let { handler ->
+            backButtonHandler?.let { handler ->
                 Image(
                     modifier = Modifier
                         .size(dimensionResource(id = R.dimen.card_header_button_size))
@@ -125,9 +132,9 @@ object SamplePlacesViewComposer {
             Title5(
                 modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Center,
-                text = placesListUiState.title.content ?: "", color = AppTheme.colors.textColor.primary,
+                text = title, color = AppTheme.colors.textColor.primary,
             )
-            placesListUiState.closeHandler?.let { handler ->
+            closeButtonHandler?.let { handler ->
                 Image(
                     modifier = Modifier
                         .weight(0.5f)
@@ -142,40 +149,67 @@ object SamplePlacesViewComposer {
                 )
             }
         }
-        placesListUiState.items.UiStates(
-            loading = {
-                LazyColumn(
-                    modifier = Modifier.fillMaxWidth(),
-                    state = lazyListState,
-                    contentPadding = PaddingValues(bottom = 8.dp),
-                ) {
-                    repeat(times = 3) {
-                        item {
-                            SearchResultPlaceholder()
+    }
+
+    @Composable
+    operator fun invoke(
+        lazyListState: LazyListState,
+        placesListUiState: PlacesListUiState,
+    ) {
+        Column(modifier = Modifier
+            .fillMaxWidth()
+            .background(AppTheme.colors.backgroundColors.primary, shape = AppTheme.shapes.poiCardBackground)) {
+            PlacesHeader(
+                title = placesListUiState.title.content.orEmpty(),
+                backButtonHandler = placesListUiState.backHandler,
+                closeButtonHandler = placesListUiState.closeHandler
+            )
+            placesListUiState.items.UiStates(
+                loading = {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth(),
+                        state = lazyListState,
+                        contentPadding = PaddingValues(bottom = 8.dp),
+                    ) {
+                        repeat(times = 3) {
+                            item {
+                                SearchResultPlaceholder()
+                            }
                         }
                     }
-                }
-            },
-            failure = {},
-            content = { content, loading, error ->
-                LazyColumn(
-                    modifier = Modifier.fillMaxWidth(),
-                    state = lazyListState,
-                    contentPadding = PaddingValues(bottom = 8.dp),
-                ) {
-                    content.forEachIndexed { index, result ->
-                        item {
-                            InfoCard(
-                                number = index + 1,
-                                title = result.name,
-                                eta = result.distanceMeters?.toLong()
-                                    .toString() + "m · " + result.etaMinutes?.toLong() + "min",
-                                onItemSelected = { placesListUiState.itemSelected(index) },
-                            )
+                },
+                failure = {},
+                content = { content, loading, error ->
+                    LazyColumn(
+                        modifier = Modifier.fillMaxWidth(),
+                        state = lazyListState,
+                        contentPadding = PaddingValues(bottom = 8.dp),
+                    ) {
+                        content.forEachIndexed { index, result ->
+                            item {
+                                InfoCard(
+                                    number = index + 1,
+                                    title = result.name,
+                                    eta = result.distanceMeters?.toLong()
+                                        .toString() + "m · " + result.etaMinutes?.toLong() + "min",
+                                    onItemSelected = { placesListUiState.itemSelected(index) },
+                                )
+                            }
                         }
                     }
-                }
-            },
-        )
+                },
+            )
+        }
     }
 }
+
+@Preview(device = Devices.AUTOMOTIVE_1024p)
+@Composable
+private fun HeaderPreview() {
+    LightDashTheme {
+        PlacesHeader(title = "Coffee", backButtonHandler = null, closeButtonHandler = {})
+    }
+}
+
+
+

--- a/app/src/main/java/com/mapbox/dash/example/SamplePlacesViewComposer.kt
+++ b/app/src/main/java/com/mapbox/dash/example/SamplePlacesViewComposer.kt
@@ -1,0 +1,181 @@
+@file:SuppressWarnings("MagicNumber", "LongMethod")
+
+package com.mapbox.dash.example
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.mapbox.dash.compose.component.Body1
+import com.mapbox.dash.compose.component.Title4
+import com.mapbox.dash.compose.component.Title5
+import com.mapbox.dash.sdk.config.api.UiStates
+import com.mapbox.dash.theming.compose.AppTheme
+import com.mapbox.dash.view.compose.R
+import com.mapbox.nav.gm.map.presentation.ui.PlacesListUiState
+
+object SamplePlacesViewComposer {
+
+    @Composable
+    fun ShimmerItem(modifier: Modifier, shape: Shape = RoundedCornerShape(8.dp)) {
+        val color = Color(0xFFA1AABB)
+        val gradientColors = listOf(color.copy(alpha = 0.1f), color.copy(alpha = 0.3f), color.copy(alpha = 0.1f))
+        Spacer(modifier = modifier.background(Brush.horizontalGradient(gradientColors), shape))
+    }
+
+    @Composable
+    fun InfoCard(number: Int, title: String, eta: String, onItemSelected: () -> Unit) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+                .background(
+                    AppTheme.colors.backgroundColors.tertiary,
+                    shape = AppTheme.shapes.searchPanelBackground,
+                ),
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+                    .clickable(onClick = onItemSelected),
+            ) {
+                Body1(
+                    text = "#$number",
+                    color = AppTheme.colors.textColor.primary,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Title4(
+                    text = title,
+                    color = AppTheme.colors.textColor.primary,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Title5(
+                    text = "ETA: $eta",
+                    color = AppTheme.colors.textColor.secondary,
+                )
+            }
+        }
+    }
+
+    @Composable
+    internal fun SearchResultPlaceholder(modifier: Modifier = Modifier) {
+        Column(modifier = modifier) {
+            ShimmerItem(
+                modifier = Modifier
+                    .height(24.dp)
+                    .width(370.dp),
+            )
+            val secondRowModifier = Modifier
+                .padding(top = 4.dp)
+                .height(34.dp)
+            ShimmerItem(modifier = secondRowModifier.defaultMinSize(440.dp))
+        }
+    }
+
+    @Composable
+    operator fun invoke(
+        lazyListState: LazyListState,
+        placesListUiState: PlacesListUiState,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(32.dp),
+        ) {
+            placesListUiState.backHandler?.let { handler ->
+                Image(
+                    modifier = Modifier
+                        .size(dimensionResource(id = R.dimen.card_header_button_size))
+                        .clip(CircleShape)
+                        .background(AppTheme.colors.buttonColors.primary)
+                        .clickable(onClick = handler)
+                        .wrapContentSize()
+                        .size(dimensionResource(id = R.dimen.card_header_icon_size)),
+                    painter = painterResource(id = AppTheme.icons.controls.longArrowLeft),
+                    contentDescription = null,
+                )
+            }
+            Title5(
+                modifier = Modifier.weight(1f),
+                textAlign = TextAlign.Center,
+                text = placesListUiState.title.content ?: "", color = AppTheme.colors.textColor.primary,
+            )
+            placesListUiState.closeHandler?.let { handler ->
+                Image(
+                    modifier = Modifier
+                        .weight(0.5f)
+                        .size(dimensionResource(id = R.dimen.card_header_button_size))
+                        .clip(CircleShape)
+                        .background(AppTheme.colors.buttonColors.primary)
+                        .clickable(onClick = handler)
+                        .wrapContentSize()
+                        .size(dimensionResource(id = R.dimen.card_header_icon_size)),
+                    painter = painterResource(id = AppTheme.icons.controls.cross),
+                    contentDescription = null,
+                )
+            }
+        }
+        placesListUiState.items.UiStates(
+            loading = {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth(),
+                    state = lazyListState,
+                    contentPadding = PaddingValues(bottom = 8.dp),
+                ) {
+                    repeat(times = 3) {
+                        item {
+                            SearchResultPlaceholder()
+                        }
+                    }
+                }
+            },
+            failure = {},
+            content = { content, loading, error ->
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth(),
+                    state = lazyListState,
+                    contentPadding = PaddingValues(bottom = 8.dp),
+                ) {
+                    content.forEachIndexed { index, result ->
+                        item {
+                            InfoCard(
+                                number = index + 1,
+                                title = result.name,
+                                eta = result.distanceMeters?.toLong()
+                                    .toString() + "m · " + result.etaMinutes?.toLong() + "min",
+                                onItemSelected = { placesListUiState.itemSelected(index) },
+                            )
+                        }
+                    }
+                }
+            },
+        )
+    }
+}

--- a/app/src/main/res/layout/layout_customization_menu.xml
+++ b/app/src/main/res/layout/layout_customization_menu.xml
@@ -436,6 +436,14 @@
             android:textAllCaps="true"
             />
 
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/toggleCustomPlacesList"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Set custom places composer"
+            android:textAllCaps="true"
+            />
+
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
In this example we use `DashNavigationFragment` to `setPlacesPreview` via 
```
class PlacesListUiState(
    val title: DataState<String>,
    val items: DataState<List<DashSearchResult>>,
    val itemSelected: (Int) -> Unit,

    val closeHandler: BackCloseButtonHandler?,
    val backHandler: BackCloseButtonHandler?,
)
```

![Screenshot_20240801_145915](https://github.com/user-attachments/assets/84c59208-dea6-42eb-bea4-213c3ed58aae)

 