### PR TITLE
 Add data inputs example for compass

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,6 +26,9 @@ android {
         create("CustomCluster") {
             dimension = "devMenuDefaults"
         }
+        create("PrivateSdk") {
+            dimension = "devMenuDefaults"
+        }
     }
 
     buildTypes {
@@ -100,4 +103,8 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     testImplementation("junit:junit:4.13.2")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:1.1.5")
+}
+
+fun DependencyHandler.privateSdk(dependencyNotation: String) {
+    add("PrivateSdkImplementation", dependencyNotation)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     implementation("com.mapbox.navigationux:android:1.0.0-beta.43")
     implementation("com.mapbox.navigationux:cluster:1.0.0-beta.43")
     implementation("com.mapbox.navigationux:weather-api:1.0.0-beta.43")
+    implementation("com.mapbox.navigationux:data-inputs:1.0.0-beta.43")
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.1")

--- a/app/src/main/java/com/mapbox/dash/example/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/dash/example/MainActivity.kt
@@ -462,18 +462,6 @@ private val weatherVM: WeatherViewModel by viewModels()
             controller.stopNavigation()
         }
 
-        bindSwitch(
-            switch = menuBinding.customCompassDataInputs,
-            state = setCustomCompassDataInputs,
-        ) { enabled ->
-            sampleSensorEventManager?.compassData?.observeWhenStarted(this) {
-                if (enabled) {
-                    Log.d(TAG, "Updating compass data: $it")
-                    Dash.controller.updateCompassData(it)
-                }
-            }
-        }
-
         menuBinding.customCompassDataInputs.setOnCheckedChangeListener { _, isChecked ->
             setCustomCompassDataInputs.value = isChecked
         }

--- a/app/src/main/java/com/mapbox/dash/example/SampleSensorEventManager.kt
+++ b/app/src/main/java/com/mapbox/dash/example/SampleSensorEventManager.kt
@@ -1,0 +1,131 @@
+package com.mapbox.dash.example
+
+import android.content.Context
+import android.hardware.GeomagneticField
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.util.Log
+import com.mapbox.common.location.LocationServiceFactory
+import com.mapbox.dash.sdk.data.inputs.api.model.DashCompassData
+import com.mapbox.navigation.base.geometry.Angle.Companion.degrees
+import com.mapbox.navigation.base.geometry.Point3D
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+internal class SampleSensorEventManager(private val context: Context) : SensorEventListener {
+
+    private val sensorManager by lazy {
+        context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+    }
+
+    fun onResume() {
+        val accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        val magnetometer = sensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD)
+        if (accelerometer == null) {
+            Log.d(TAG, "Accelerometer is not available")
+        } else if (magnetometer == null) {
+            Log.d(TAG, "Magnetometer is not available")
+        } else {
+            sensorManager.registerListener(this, accelerometer, SensorManager.SENSOR_DELAY_NORMAL)
+            sensorManager.registerListener(this, magnetometer, SensorManager.SENSOR_DELAY_NORMAL)
+        }
+    }
+
+    fun onPause() {
+        sensorManager.unregisterListener(this)
+    }
+
+    private val _compassData = MutableSharedFlow<DashCompassData>(extraBufferCapacity = 1)
+    val compassData = _compassData.distinctUntilChanged()
+
+    private var currentCompassData: DashCompassData? = null
+
+    private var gravity: FloatArray? = null
+    private var geomagnetic: FloatArray? = null
+    private var azimuth = 0f
+
+    override fun onSensorChanged(event: SensorEvent) {
+        if (event.sensor.type == Sensor.TYPE_ACCELEROMETER) {
+            gravity = event.values
+        } else if (event.sensor.type == Sensor.TYPE_MAGNETIC_FIELD) {
+            geomagnetic = event.values
+        }
+
+        val latestGravity = gravity
+        val latestGeomagnetic = geomagnetic
+        if (latestGravity != null && latestGeomagnetic != null) {
+            val rotationMatrix = FloatArray(9)
+            val inclinationMatrix = FloatArray(9)
+
+            val rotationMatrixSuccess = SensorManager.getRotationMatrix(
+                rotationMatrix,
+                inclinationMatrix,
+                latestGravity,
+                latestGeomagnetic,
+            )
+
+            if (rotationMatrixSuccess) {
+                val orientation = FloatArray(3)
+                SensorManager.getOrientation(rotationMatrix, orientation)
+                azimuth = Math.toDegrees(orientation[0].toDouble()).normalizeDegrees().toFloat()
+
+                calculateTrueNorth(azimuth) { trueNorth ->
+                    val rawGeomagneticData = Point3D(
+                        x = latestGravity[0].toDouble(),
+                        y = latestGravity[1].toDouble(),
+                        z = latestGravity[2].toDouble(),
+                    )
+
+                    val newCompassData = DashCompassData(
+                        magneticHeading = azimuth.degrees,
+                        trueHeading = trueNorth?.degrees,
+                        headingAccuracy = null,
+                        rawGeomagneticData = rawGeomagneticData,
+                        monotonicTimestampNanoseconds = System.nanoTime(),
+                    )
+                    _compassData.tryEmit(newCompassData)
+                    currentCompassData = newCompassData
+                }
+            }
+        }
+    }
+
+    override fun onAccuracyChanged(sens: Sensor, accuracy: Int) {
+        /**
+         * Should we map accuracy level (SENSOR_STATUS_*) to some predefined absolute value
+         * we can us in [CompassData.headingAccuracy]?
+         */
+    }
+
+    private fun calculateTrueNorth(magneticNorth: Float, resultCallback: (Float?) -> Unit) {
+        LocationServiceFactory.getOrCreate().getDeviceLocationProvider(null)
+            .onValue { provider ->
+                provider.getLastLocation { location ->
+                    val altitude = location?.altitude?.toFloat()
+                    if (location != null && altitude != null) {
+                        val geomagneticField = GeomagneticField(
+                            location.latitude.toFloat(),
+                            location.longitude.toFloat(),
+                            altitude,
+                            location.timestamp,
+                        )
+                        resultCallback((magneticNorth + geomagneticField.declination).normalizeDegrees())
+                    } else {
+                        resultCallback(null)
+                    }
+                }
+            }.onError {
+                resultCallback(null)
+            }
+    }
+
+    private fun Double.normalizeDegrees() = ((this % 360.0) + 360.0) % 360.0
+
+    private fun Float.normalizeDegrees() = ((this % 360F) + 360F) % 360F
+
+    private companion object {
+        const val TAG = "SensorEventManager"
+    }
+}

--- a/app/src/main/res/layout/layout_customization_menu.xml
+++ b/app/src/main/res/layout/layout_customization_menu.xml
@@ -17,7 +17,7 @@
         android:paddingBottom="10dp"
         android:text="Dash Customizations"
         android:textColor="#fff"
-        android:textSize="16sp"
+        android:textSize="18sp"
         android:textStyle="bold"
         />
 
@@ -143,6 +143,14 @@
             android:layout_gravity="center"
             android:backgroundTint="@android:color/holo_blue_dark"
             android:text="Stop navigation"
+            android:textAllCaps="true"
+            />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/customCompassDataInputs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Custom compass data inputs"
             android:textAllCaps="true"
             />
 


### PR DESCRIPTION
The UXF SDK exposes [DataInputsManager](https://docs.mapbox.com/android/navigation/api/uxframework/1.0.0-beta.37/data-inputs-api/com.mapbox.dash.sdk.data.inputs.api/-dash-data-inputs-manager/?query=interface%20DashDataInputsManager) interface to allow a client to send sensor data coming from a device (or vehicle) to the UXF navigation engine.

Today, this data is supported by the mentioned API:

* **altimeterData**
* **accelerometerData**
* **rawGyroscopeData**
* **compassData**
* **etcGateInfo**
* **motionData**
* **odometryData**
* **rawGnssData**

In order to have access to DataInputsManager you should:

1.  Add a corresponding module of UXF SDK in your dependencies:

`implementation("com.mapbox.navigationux:data-inputs:1.0.0-beta.37.1")`

2. Enable this functionality in DSL API:

```
 dataInputs {
     enabled = true
 }
```
3. That's it. Now, you can use Data Inputs API via Dash.controller like this:

```
sampleSensorEventManager?.compassData?.observeWhenStarted(this) {
    if (enabled) {
        Log.d(TAG, "Updating compass data: $it")
        Dash.controller.updateCompassData(it)
    }
}
```

This PR shows how compass data from an android device can be passed to data input manager.

